### PR TITLE
Feat: Add Stats

### DIFF
--- a/app/controllers/climb_logs_controller.rb
+++ b/app/controllers/climb_logs_controller.rb
@@ -5,8 +5,6 @@ class ClimbLogsController < ApplicationController
   def index
     @climb_logs = current_user.climb_logs.last_30_days.order(:date)
     @climb_logs_by_date = @climb_logs.group_by { |climb_log| climb_log.date.to_date }
-
-    @average_per_day = @climb_logs.count / @climb_logs_by_date.size if @climb_logs_by_date.size > 0
   end
 
   def show

--- a/app/controllers/climb_logs_controller.rb
+++ b/app/controllers/climb_logs_controller.rb
@@ -3,8 +3,10 @@ class ClimbLogsController < ApplicationController
   before_action :set_climb_log, only: %i[ show edit update destroy ]
 
   def index
-    @climb_logs = ClimbLog.all.order(:date).reverse
+    @climb_logs = current_user.climb_logs.last_30_days.order(:date)
     @climb_logs_by_date = @climb_logs.group_by { |climb_log| climb_log.date.to_date }
+
+    @average_per_day = @climb_logs.count / @climb_logs_by_date.size if @climb_logs_by_date.size > 0
   end
 
   def show

--- a/app/models/climb_log.rb
+++ b/app/models/climb_log.rb
@@ -7,6 +7,7 @@ class ClimbLog < ApplicationRecord
   validate :status_consistent_with_tries
 
   scope :last_30_days, -> { where(date: 30.days.ago...) }
+  scope :from_90_to_30_days_ago, -> { where(date: 90.days.ago...30.days.ago) }
 
   def status_consistent_with_tries
     if status

--- a/app/models/climb_log.rb
+++ b/app/models/climb_log.rb
@@ -6,6 +6,8 @@ class ClimbLog < ApplicationRecord
   validates :tries, numericality: { greater_than_or_equal_to: 1 }
   validate :status_consistent_with_tries
 
+  scope :last_30_days, -> { where(date: 30.days.ago...) }
+
   def status_consistent_with_tries
     if status
       if tries == 1 && status != "Flash"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :climb_logs, dependent: :destroy
+
+  def stats
+    @stats ||= User::Stats.new(self)
+  end
 end

--- a/app/models/user/stats.rb
+++ b/app/models/user/stats.rb
@@ -1,0 +1,9 @@
+class User::Stats
+  def initialize(user)
+    @user = user
+  end
+
+  def climbs
+    @climbs ||= User::Stats::Climbs.new(@user)
+  end
+end

--- a/app/models/user/stats/climbs.rb
+++ b/app/models/user/stats/climbs.rb
@@ -1,0 +1,40 @@
+class User::Stats::Climbs
+  def initialize(user)
+    @climb_logs = user.climb_logs.last_30_days.order(:date)
+    @past_30_to_90_day_logs = user.climb_logs.from_90_to_30_days_ago
+  end
+
+  def last_30d_count
+    @climb_logs.count
+  end
+
+  def increase?
+    increased_by > 0
+  end
+
+  def increased_by
+    @climb_logs.count - @past_30_to_90_day_logs.count
+  end
+
+  def average_grade
+    @climb_logs.average(:grade)
+  end
+
+  def average_per_day
+    average(@climb_logs)
+  end
+
+  def average_per_day_increase_by
+    average_per_day - average(@past_30_to_90_day_logs)
+  end
+
+  def average_per_day_increase?
+    average_per_day_increase_by > 0
+  end
+
+  private
+  def average(climb_logs)
+    days = climb_logs.select(:date).distinct.count
+    days > 0 ? climb_logs.count.to_f / days : 0.0
+  end
+end

--- a/app/views/climb_logs/_decrease.html.erb
+++ b/app/views/climb_logs/_decrease.html.erb
@@ -1,0 +1,7 @@
+<p class="ml-2 flex items-baseline text-sm font-semibold text-red-600">
+  <svg class="size-5 shrink-0 self-center text-red-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+    <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
+  </svg>
+  <span class="sr-only"> Decreased by </span>
+  <%= decreased_by %>
+</p>

--- a/app/views/climb_logs/_increase.html.erb
+++ b/app/views/climb_logs/_increase.html.erb
@@ -1,0 +1,8 @@
+<p class="ml-2 flex items-baseline text-sm font-semibold text-green-600">
+  <svg class="size-5 shrink-0 self-center text-green-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+    <path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd" />
+  </svg>
+  <span class="sr-only"> Increased by </span>
+  <%= increased_by %>
+</p>
+

--- a/app/views/climb_logs/_stats.html.erb
+++ b/app/views/climb_logs/_stats.html.erb
@@ -1,0 +1,60 @@
+<div>
+  <h3 class="text-base font-semibold text-gray-900">Last 30 days</h3>
+
+  <dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="relative overflow-hidden rounded-lg bg-white px-4 pt-5 pb-5 shadow-sm sm:px-6 sm:pt-6">
+      <dt>
+        <div class="absolute rounded-md bg-indigo-500 p-3">
+            <svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-white" fill="none" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" width="256" height="256" viewBox="0 0 2048 2048" fill="currentColor"><path fill="currentColor" d="M1792 384h-128V256H475l768 768l-768 768h1189v-128h128v256H256v-91l805-805l-805-805v-91h1536v256z"/></svg>
+        </div>
+        <p class="ml-16 truncate text-sm font-medium text-gray-500">Total climbs</p>
+      </dt>
+      <dd class="ml-16 flex items-baseline">
+        <p class="text-2xl font-semibold text-gray-900"><%= @climb_logs.count %></p>
+        <p class="ml-2 flex items-baseline text-sm font-semibold text-green-600">
+          <svg class="size-5 shrink-0 self-center text-green-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd" />
+          </svg>
+          <span class="sr-only"> Increased by </span>
+          122
+        </p>
+      </dd>
+    </div>
+    <div class="relative overflow-hidden rounded-lg bg-white px-4 pt-5 pb-5 shadow-sm sm:px-6 sm:pt-6">
+      <dt>
+        <div class="absolute rounded-md bg-indigo-500 p-3">
+          <svg  class="size-6 text-white" fill="none" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon"xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 512 512" fill="currentColor"><path fill="currentColor" fill-rule="evenodd" d="m422.536 60.491l30.17 30.17l-61.36 61.36c22.15 28.79 35.32 64.846 35.32 103.979c0 94.256-76.41 170.666-170.666 170.666c-39.133 0-75.19-13.17-103.979-35.32L90.667 452.7l-30.17-30.17l61.205-61.204C98.92 332.317 85.334 295.746 85.334 256c0-94.257 76.41-170.667 170.666-170.667c39.745 0 76.317 13.586 105.325 36.367zm-61.704 122.044L182.535 360.83C203.33 375.431 228.664 384 256 384c70.693 0 128-57.308 128-128c0-27.337-8.57-52.672-23.168-73.465M256 128c-70.692 0-128 57.307-128 128c0 27.952 8.96 53.811 24.164 74.863l178.699-178.7C309.81 136.96 283.953 128 256 128"/></svg>
+        </div>
+        <p class="ml-16 truncate text-sm font-medium text-gray-500">Avg. Grade</p>
+      </dt>
+      <dd class="ml-16 flex items-baseline">
+        <p class="text-2xl font-semibold text-gray-900"><%= @climb_logs.average(:grade) %></p>
+        <p class="ml-2 flex items-baseline text-sm font-semibold text-green-600">
+          <svg class="size-5 shrink-0 self-center text-green-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd" />
+          </svg>
+          <span class="sr-only"> Increased by </span>
+          5.4%
+        </p>
+      </dd>
+    </div>
+    <div class="relative overflow-hidden rounded-lg bg-white px-4 pt-5 pb-5 shadow-sm sm:px-6 sm:pt-6">
+      <dt>
+        <div class="absolute rounded-md bg-indigo-500 p-3">
+          <svg  class="size-6 text-white" fill="none" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon"xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 512 512" fill="currentColor"><path fill="currentColor" fill-rule="evenodd" d="m422.536 60.491l30.17 30.17l-61.36 61.36c22.15 28.79 35.32 64.846 35.32 103.979c0 94.256-76.41 170.666-170.666 170.666c-39.133 0-75.19-13.17-103.979-35.32L90.667 452.7l-30.17-30.17l61.205-61.204C98.92 332.317 85.334 295.746 85.334 256c0-94.257 76.41-170.667 170.666-170.667c39.745 0 76.317 13.586 105.325 36.367zm-61.704 122.044L182.535 360.83C203.33 375.431 228.664 384 256 384c70.693 0 128-57.308 128-128c0-27.337-8.57-52.672-23.168-73.465M256 128c-70.692 0-128 57.307-128 128c0 27.952 8.96 53.811 24.164 74.863l178.699-178.7C309.81 136.96 283.953 128 256 128"/></svg>
+        </div>
+        <p class="ml-16 truncate text-sm font-medium text-gray-500">Avg. Climbs per Session</p>
+      </dt>
+      <dd class="ml-16 flex items-baseline">
+        <p class="text-2xl font-semibold text-gray-900"><%= @average_per_day || 0 %></p>
+        <p class="ml-2 flex items-baseline text-sm font-semibold text-red-600">
+          <svg class="size-5 shrink-0 self-center text-red-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+            <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
+          </svg>
+          <span class="sr-only"> Decreased by </span>
+          3.2%
+        </p>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/app/views/climb_logs/_stats.html.erb
+++ b/app/views/climb_logs/_stats.html.erb
@@ -10,14 +10,12 @@
         <p class="ml-16 truncate text-sm font-medium text-gray-500">Total climbs</p>
       </dt>
       <dd class="ml-16 flex items-baseline">
-        <p class="text-2xl font-semibold text-gray-900"><%= @climb_logs.count %></p>
-        <p class="ml-2 flex items-baseline text-sm font-semibold text-green-600">
-          <svg class="size-5 shrink-0 self-center text-green-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-            <path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd" />
-          </svg>
-          <span class="sr-only"> Increased by </span>
-          122
-        </p>
+        <p class="text-2xl font-semibold text-gray-900"><%= current_user.stats.climbs.last_30d_count %></p>
+        <% if current_user.stats.climbs.increase? %>
+          <%= render "increase", increased_by: current_user.stats.climbs.increased_by %>
+        <% else %>
+          <%= render "decrease", decreased_by: current_user.stats.climbs.increased_by * -1 %>
+        <% end %>
       </dd>
     </div>
     <div class="relative overflow-hidden rounded-lg bg-white px-4 pt-5 pb-5 shadow-sm sm:px-6 sm:pt-6">
@@ -29,13 +27,6 @@
       </dt>
       <dd class="ml-16 flex items-baseline">
         <p class="text-2xl font-semibold text-gray-900"><%= @climb_logs.average(:grade) %></p>
-        <p class="ml-2 flex items-baseline text-sm font-semibold text-green-600">
-          <svg class="size-5 shrink-0 self-center text-green-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-            <path fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" clip-rule="evenodd" />
-          </svg>
-          <span class="sr-only"> Increased by </span>
-          5.4%
-        </p>
       </dd>
     </div>
     <div class="relative overflow-hidden rounded-lg bg-white px-4 pt-5 pb-5 shadow-sm sm:px-6 sm:pt-6">
@@ -46,13 +37,12 @@
         <p class="ml-16 truncate text-sm font-medium text-gray-500">Avg. Climbs per Session</p>
       </dt>
       <dd class="ml-16 flex items-baseline">
-        <p class="text-2xl font-semibold text-gray-900"><%= @average_per_day || 0 %></p>
-        <p class="ml-2 flex items-baseline text-sm font-semibold text-red-600">
-          <svg class="size-5 shrink-0 self-center text-red-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-            <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
-          </svg>
-          <span class="sr-only"> Decreased by </span>
-          3.2%
+        <p class="text-2xl font-semibold text-gray-900"><%= current_user.stats.climbs.average_per_day %></p>
+        <% if current_user.stats.climbs.average_per_day_increase? %>
+          <%= render "increase", increased_by: current_user.stats.climbs.average_per_day_increase_by %>
+        <% else %>
+          <%= render "decrease", decreased_by: current_user.stats.climbs.average_per_day_increase_by * -1 %>
+        <% end %>
         </p>
       </dd>
     </div>

--- a/app/views/climb_logs/index.html.erb
+++ b/app/views/climb_logs/index.html.erb
@@ -2,7 +2,8 @@
 <p style="color: green"><%= notice %></p>
 <div>
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-  <div class="flex flex-wrap items-center gap-6 px-4 sm:flex-nowrap sm:px-6 lg:px-8">
+    <%= render "stats" %>
+  <div class="mt-20 flex flex-wrap items-center gap-6 px-4 sm:flex-nowrap sm:px-6 lg:px-8">
     <h1 class="text-base/7 font-semibold text-gray-900">Climb Logs</h1>
     <div class="order-last flex w-full gap-x-8 text-sm/6 font-semibold sm:order-0 sm:w-auto sm:border-l sm:border-gray-200 sm:pl-6 sm:text-sm/7">
       <a href="#" class="text-blue-600">Last 7 days</a>

--- a/spec/factories/climb_log.rb
+++ b/spec/factories/climb_log.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     grade { Faker::Number.non_zero_digit }
     sequence :status, %w[Flash Top Project].cycle
     sequence :climb_type, ClimbLog.climb_types.values.cycle
+    user
     tries {
       if status == 'Flash'
         1

--- a/spec/factories/climb_log.rb
+++ b/spec/factories/climb_log.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :climb_log do
-    date { Faker::Date.in_date_period }
+    date { Faker::Date.between(from: 30.days.ago, to: Date.today) }
     route_name { Faker::Name.name }
     location { Faker::FunnyName.name }
     grade { Faker::Number.non_zero_digit }

--- a/spec/models/climb_log_spec.rb
+++ b/spec/models/climb_log_spec.rb
@@ -23,4 +23,11 @@ RSpec.describe ClimbLog, type: :model do
       expect(subject).not_to be_valid
     end
   end
+  context '#last_30_days' do
+    it 'should return climbs from the last 30 days' do
+      FactoryBot.create(:climb_log, :yesterday)
+      FactoryBot.create(:climb_log, date: 40.days.ago)
+      expect(ClimbLog.last_30_days.count).to eq(1)
+    end
+  end
 end

--- a/spec/models/climb_log_spec.rb
+++ b/spec/models/climb_log_spec.rb
@@ -23,11 +23,4 @@ RSpec.describe ClimbLog, type: :model do
       expect(subject).not_to be_valid
     end
   end
-  context '#last_30_days' do
-    it 'should return climbs from the last 30 days' do
-      FactoryBot.create(:climb_log, :yesterday)
-      FactoryBot.create(:climb_log, date: 40.days.ago)
-      expect(ClimbLog.last_30_days.count).to eq(1)
-    end
-  end
 end

--- a/spec/models/user/stats/climbs_spec.rb
+++ b/spec/models/user/stats/climbs_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe User::Stats::Climbs, type: :model do
+  let!(:user) { FactoryBot.create(:user) }
+  let(:subject) { User::Stats::Climbs.new(user) }
+  before(:each) {
+    FactoryBot.create(:climb_log, :yesterday, user: user)
+    FactoryBot.create(:climb_log, :yesterday, user: user)
+    FactoryBot.create(:climb_log, date: 40.days.ago, user: user)
+  }
+
+  context 'last 30 days' do
+    it 'returns the number of climbs' do
+      expect(subject.last_30d_count).to eq(2)
+    end
+    it 'returns the increase' do
+      expect(subject.increased_by).to eq(1)
+    end
+    it 'returns the average per day' do
+      expect(subject.average_per_day).to eq(2.0)
+    end
+    it 'returns the average per day increase ' do
+      expect(subject.average_per_day_increase_by).to eq(1.0)
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

It adds three stat items to the index page. showing number of climbs in the last 30 days, the average grade and the average number of climbs per session

### Screenshot
<img width="1446" alt="Bildschirmfoto 2025-06-17 um 12 55 45" src="https://github.com/user-attachments/assets/5a030793-0e99-4157-84f2-b37b4f7af2cb" />

### ToDo:
- [x] either remove the trajectory or put in real numbers