### PR TITLE
feat: add toggle to add another log

### DIFF
--- a/app/controllers/climb_logs_controller.rb
+++ b/app/controllers/climb_logs_controller.rb
@@ -12,6 +12,8 @@ class ClimbLogsController < ApplicationController
 
   def new
     @climb_log = ClimbLog.new
+
+    session[:add_another] ||= false
   end
 
   def edit
@@ -19,11 +21,16 @@ class ClimbLogsController < ApplicationController
 
   def create
     @climb_log = current_user.climb_logs.build(climb_log_params)
+    session[:add_another] = params[:climb_log][:add_another] == "true"
 
     respond_to do |format|
       if @climb_log.save
-        format.html { redirect_to @climb_log, notice: "Climb log was successfully created." }
-        format.json { render :show, status: :created, location: @climb_log }
+        if session[:add_another]
+          format.html { redirect_to new_climb_log_path, notice: "Climb log was successfully created." }
+        else
+          format.html { redirect_to @climb_log, notice: "Climb log was successfully created." }
+          format.json { render :show, status: :created, location: @climb_log }
+        end
       else
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @climb_log.errors, status: :unprocessable_entity }

--- a/app/views/climb_logs/_form.html.erb
+++ b/app/views/climb_logs/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: climb_log) do |form| %>
-  <div class="space-y-12">
+  <div class="space-y-12" x-data="{ addAnother: <%= session[:add_another] %>}">
     <div class="border-b border-gray-900/10 pb-12">
       <p class="mt-1 text-sm/6 text-gray-600">This information will be displayed publicly so be careful what you share.</p>
 
@@ -54,7 +54,7 @@
         </div>
         <div class="mt-2 grid grid-cols-3 gap-3 sm:grid-cols-6">
           <% ClimbLog.climb_types.each do |name, value| %>
-            <label aria-label="4 GB" class="group relative flex items-center justify-center rounded-md border border-gray-300 bg-white p-3 has-checked:border-indigo-600 has-checked:bg-indigo-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-indigo-600 has-disabled:opacity-25">
+            <label aria-label="<%= name %>" class="group relative flex items-center justify-center rounded-md border border-gray-300 bg-white p-3 has-checked:border-blue-600 has-checked:bg-blue-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-blue-600 has-disabled:opacity-25">
               <%= form.radio_button :climb_type, value, class: "absolute inset-0 appearance-none focus:outline-none disabled:cursor-not-allowed" %>
               <span class="text-sm font-medium group-has-checked:text-white"><%= name %></span>
             </label>
@@ -93,8 +93,17 @@
         </div>
       </div>
 
+      <div class="flex items-center mt-10">
+        <button @click="addAnother = !addAnother" type="button" class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent  transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-hidden" role="switch" aria-checked="false" aria-labelledby="annual-billing-label" :class="addAnother ? 'bg-blue-600' : 'bg-gray-200'">
+          <span aria-hidden="true" class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out" :class="addAnother ? 'translate-x-5' : 'translate-x-0'"></span>
+        </button>
+        <span class="ml-3 text-sm" id="create-another-label">
+          <span class="font-medium text-gray-900">Create another after saving</span>
+        </span>
+        <%= form.hidden_field :add_another, { ":value": "addAnother" } %>
+      </div>
 
-      <div class="mt-10">
+      <div class="mt-5">
         <%= form.submit class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600" %>
       </div>
     <% end %>

--- a/app/views/climb_logs/new.html.erb
+++ b/app/views/climb_logs/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "New climb log" %>
+<p style="color: green"><%= notice %></p>
 
 <h1>New climb log</h1>
 

--- a/app/views/climb_logs/show.html.erb
+++ b/app/views/climb_logs/show.html.erb
@@ -3,8 +3,11 @@
 <div class="border-b border-gray-200 pb-5 sm:flex sm:items-center sm:justify-between">
   <h3 class="text-base font-semibold text-gray-900">Climb Log</h3>
   <div class="mt-3 flex sm:mt-0 sm:ml-4">
-    <%= button_to "Destroy", @climb_log, method: :delete, class: "inline-flex items-center rounded-md bg-red-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50" %>
+  <%= link_to "Create new climb log", new_climb_log_path, class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50" %>
   <%= link_to "Edit this climb log", edit_climb_log_path(@climb_log), class: "ml-3 inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600" %>
   </div>
 </div>
 <%= render @climb_log %>
+<div class="mt-20">
+    <%= button_to "Destroy", @climb_log, method: :delete, class: "inline-flex items-center rounded-md bg-red-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50" %>
+</div>


### PR DESCRIPTION
## What does this PR do?
Add a toggl and a button to create new climb logs. from the edit and the show views.

When creating a climb log you might want to add a new one right away. or you want to add a new one after you just created one, moved on to the next climb but your browser is still on the newly created one

### Screenshot
<img width="271" alt="Bildschirmfoto 2025-06-19 um 09 05 21" src="https://github.com/user-attachments/assets/13fac6b5-749b-4c12-9f2a-b21886b6c694" />
<img width="500" alt="Bildschirmfoto 2025-06-19 um 09 05 35" src="https://github.com/user-attachments/assets/7a6724f1-8a77-4c38-ad51-b0ecdd580fee" />
